### PR TITLE
Fix Citizens2 compatiblity

### DIFF
--- a/src/main/java/me/swipez/terminatornpc/TerminatorNPC.java
+++ b/src/main/java/me/swipez/terminatornpc/TerminatorNPC.java
@@ -64,14 +64,4 @@ public final class TerminatorNPC extends JavaPlugin {
         // Register command classes
         commands.register(TerminatorCommands.class);
     }
-
-    private boolean suggestClosestModifier(CommandSender sender, String command, String modifier) {
-        String closest = commands.getClosestCommandModifier(command, modifier);
-        if (!closest.isEmpty()) {
-            sender.sendMessage(ChatColor.GRAY + Messaging.tr(Messages.UNKNOWN_COMMAND));
-            sender.sendMessage(StringHelper.wrap(" /") + command + " " + StringHelper.wrap(closest));
-            return true;
-        }
-        return false;
-    }
 }

--- a/src/main/java/me/swipez/terminatornpc/TerminatorNPC.java
+++ b/src/main/java/me/swipez/terminatornpc/TerminatorNPC.java
@@ -55,11 +55,6 @@ public final class TerminatorNPC extends JavaPlugin {
 
     @Override
     public boolean onCommand(CommandSender sender, org.bukkit.command.Command command, String cmdName, String[] args) {
-        String modifier = args.length > 0 ? args[0] : "";
-        if (!commands.hasCommand(command, modifier) && !modifier.isEmpty()) {
-            return suggestClosestModifier(sender, command.getName(), modifier);
-        }
-
         Object[] methodArgs = { sender, null };
         return commands.executeSafe(command, args, sender, methodArgs);
     }


### PR DESCRIPTION
Since the newest version of Citizens 2 removed a method that TerminatorNPC used, it broke compatibility with the plugin. In this PR I fixed this issue by simply removing the usage of said method.

The method allowed us to check if the command the user gave in was valid, and if not, it would suggest one that looks similar. In the latest versions of Citizens this changed, it automatically does this check in the background. As a result, we can safely remove this command suggestion check.
